### PR TITLE
Fixes to Travis CI build

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -34,27 +34,28 @@ platforms:
 
 suites:
   - name: nomad-install
-  - name: nomad-install_build
-    provisioner:
-      state_top:
-        base:
-          '*':
-            - golang
-            - nomad
-      pillars:
-        top.sls:
-          base:
-            '*':
-              - golang
-              - nomad
-              - nomad-build
-        nomad-build.sls:
-            nomad:
-              build: true
-        golang.sls:
-            golang:
-              lookup:
-                version: 1.7.5
+  # This one should be tested locally as it times out on Travis CI
+  # - name: nomad-install_build
+  #   provisioner:
+  #     state_top:
+  #       base:
+  #         '*':
+  #           - golang
+  #           - nomad
+  #     pillars:
+  #       top.sls:
+  #         base:
+  #           '*':
+  #             - golang
+  #             - nomad
+  #             - nomad-build
+  #       nomad-build.sls:
+  #           nomad:
+  #             build: true
+  #       golang.sls:
+  #           golang:
+  #             lookup:
+  #               version: 1.7.5
   - name: nomad-config
   - name: nomad-uninstall
     provisioner:

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,5 +12,5 @@ before_install:
   # Installing testinfra and requirements
   - pip install -r requirements.txt
 
-script: travis_wait bundle exec kitchen verify
+script: bundle exec kitchen verify
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,4 @@
-language: python
-
-python:
-  - '2.7'
+language: ruby
 
 sudo: required
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,3 +16,4 @@ before_install:
   - pip install -r requirements.txt
 
 script: bundle exec kitchen verify
+

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,5 +12,5 @@ before_install:
   # Installing testinfra and requirements
   - pip install -r requirements.txt
 
-script: bundle exec kitchen verify
+script: travis_wait bundle exec kitchen verify
 


### PR DESCRIPTION
The current state of the Travis CI files committed to the repository requiring the "build from source test" to be executed as part of the default test suite. This test times out on the 20 minutes limit even with `travis_wait` enabled as the test command. 

This pull request fixes this behaviour by disabling the "build from source" test.