### PR TITLE
Add the option to use a local nomad service file

### DIFF
--- a/nomad/defaults.yaml
+++ b/nomad/defaults.yaml
@@ -3,11 +3,12 @@
 # service_hash is the SHA1 for the service file
 
 nomad:
-  bin_dir: '/usr/bin'
-  config_dir: '/etc/nomad'
-  version: '0.8.7'
+  use_local_service_file: False
+  bin_dir: "/usr/bin"
+  config_dir: "/etc/nomad.d"
+  version: "0.8.7"
   service_hash: fdc512a9e7e6a55303f12d4405676ec7c8116af6
   service: True
   build: False
   config:
-    data_dir: '/var/lib/nomad'
+    data_dir: "/var/lib/nomad"

--- a/nomad/files/nomad.service.j2
+++ b/nomad/files/nomad.service.j2
@@ -1,0 +1,28 @@
+[Unit]
+Description=Nomad
+Documentation=https://nomadproject.io/docs/
+Wants=network-online.target
+After=network-online.target
+
+# When using Nomad with Consul it is not necessary to start Consul first. These
+# lines start Consul before Nomad as an optimization to avoid Nomad logging
+# that Consul is unavailable at startup.
+#Wants=consul.service
+#After=consul.service
+
+[Service]
+ExecReload=/bin/kill -HUP $MAINPID
+ExecStart=/usr/local/bin/nomad agent -config {{ config_dir }}
+KillMode=process
+KillSignal=SIGINT
+LimitNOFILE=65536
+LimitNPROC=infinity
+Restart=on-failure
+RestartSec=2
+StartLimitBurst=3
+StartLimitIntervalSec=10
+TasksMax=infinity
+OOMScoreAdjust=-1000
+
+[Install]
+WantedBy=multi-user.target

--- a/nomad/install.sls
+++ b/nomad/install.sls
@@ -134,8 +134,14 @@ nomad-install-binary:
 nomad-install-service:
   file.managed:
     - name: /etc/systemd/system/nomad.service
+    {% if nomad.use_local_service_file %}
+    - source: salt://nomad/files/nomad.service.j2
+    - context:
+        config_dir: {{ nomad.config_dir }}
+    {% else %}
     - source: https://raw.githubusercontent.com/hashicorp/nomad/v{{ nomad.version }}/dist/systemd/nomad.service
     - source_hash: {{ nomad.service_hash }}
+    {% endif %}
     - onchanges:
       - nomad-install-binary
   module.run:

--- a/pillar.example
+++ b/pillar.example
@@ -2,7 +2,8 @@
 
 nomad:
   bin_dir: /usr/bin
-  config_dir: /etc/nomad
+  config_dir: /etc/nomad.d
+  use_local_service_file: False
   config:
     data_dir: /var/lib/nomad
     # Nodes not bound to consul must be configured to advertise themselves.

--- a/test/integration/nomad-config/testinfra/test_nomad_config.py
+++ b/test/integration/nomad-config/testinfra/test_nomad_config.py
@@ -1,11 +1,11 @@
 def test_config_dir(File):
-    file = File('/etc/nomad')
+    file = File('/etc/nomad.d')
     assert file.is_directory
     assert file.user == 'root'
 
 
 def test_config_file_exists_and_owner(File):
-    file = File('/etc/nomad/nomad.hcl')
+    file = File('/etc/nomad.d/nomad.hcl')
     assert file.is_file
     assert file.user == 'root'
 

--- a/test/integration/nomad-install/testinfra/test_nomad_install.py
+++ b/test/integration/nomad-install/testinfra/test_nomad_install.py
@@ -8,7 +8,7 @@ def test_binary_created(File):
 
 
 def test_config_dir_created(File):
-    file = File('/etc/nomad')
+    file = File('/etc/nomad.d')
     assert file.exists
     assert file.is_directory
     assert file.user == 'root'
@@ -17,7 +17,7 @@ def test_config_dir_created(File):
 
 
 def test_config_file_created(File):
-    file = File('/etc/nomad/nomad.hcl')
+    file = File('/etc/nomad.d/nomad.hcl')
     assert file.exists
     assert file.is_file
     assert file.user == 'root'

--- a/test/integration/nomad-uninstall/testinfra/test_nomad_uninstall.py
+++ b/test/integration/nomad-uninstall/testinfra/test_nomad_uninstall.py
@@ -4,12 +4,12 @@ def test_binary_absent(File):
 
 
 def test_config_file_absent(File):
-    file = File('/etc/nomad/nomad.hcl')
+    file = File('/etc/nomad.d/nomad.hcl')
     assert not file.exists
 
 
 def test_config_dir_absent(File):
-    file = File('/etc/nomad')
+    file = File('/etc/nomad.d')
     assert not file.exists
 
 


### PR DESCRIPTION
### PR progress checklist (to be filled in by reviewers)
<!-- Please leave this checklist for reviewers to tick as they work through the PR. -->

- [ ] Changes to documentation are appropriate (or tick if not required)
- [ ] Changes to tests are appropriate (or tick if not required)
- [ ] Reviews completed

---

### What type of PR is this?

#### Primary type

- [ ] `[build]`    Changes related to the build system
- [ ] `[chore]`    Changes to the build process or auxiliary tools and libraries such as documentation generation
- [ ] `[ci]`       Changes to the continuous integration configuration
- [x] `[feat]`     A new feature
- [x] `[fix]`      A bug fix
- [ ] `[perf]`     A code change that improves performance
- [ ] `[refactor]` A code change that neither fixes a bug nor adds a feature
- [ ] `[revert]`   A change used to revert a previous commit
- [ ] `[style]`    Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc.)

#### Secondary type

- [ ] `[docs]`     Documentation changes
- [ ] `[test]`     Adding missing or correcting existing tests

### Does this PR introduce a `BREAKING CHANGE`?

No.

### Related issues and/or pull requests

### Describe the changes you're proposing
This PR introduces an option to use a local Nomad service file managed by this formula rather than only downloading it from the remote github repository.

Use case: We're using Nomad enterprise edition, but this formula breaks when using `+ent` versions. Adding the option to use a local systemd service file provides a backwards compatible option to use `0.12.5+ent` in the `version` pillar data in conjunction with `use_local_service_file: True`.

### Pillar / config required to test the proposed changes
```yaml
nomad:
  version: 0.12.5+ent
  use_local_service_file: True
```

### Debug log showing how the proposed changes work

### Documentation checklist

- [ ] Updated the `README` (e.g. `Available states`).
- [x] Updated `pillar.example`.

### Testing checklist

- [ ] Included in Kitchen (i.e. under `state_top`).
- [ ] Covered by new/existing tests (e.g. InSpec, Serverspec, etc.).
- [ ] Updated the relevant test pillar.

### Additional context

Issue can be seen using any Nomad enterprise version string from releases.hashicorp.com.
