### PR TITLE
Fix jinja template issue

### DIFF
--- a/nomad/install.sls
+++ b/nomad/install.sls
@@ -136,6 +136,9 @@ nomad-install-service:
     - name: /etc/systemd/system/nomad.service
     {% if nomad.use_local_service_file %}
     - source: salt://nomad/files/nomad.service.j2
+    - show_changes: true
+    - template: jinja
+    - keep_source: true
     - context:
         config_dir: {{ nomad.config_dir }}
     {% else %}


### PR DESCRIPTION
Apologies: This is a PR to fix an issue with: https://github.com/saltstack-formulas/nomad-formula/pull/6
The file uses jinja templating for `{{ config_dir }}`

Previous testing was done with the Packer salt-masterless provisioner and I didn't realize the issue until after.
