### PR TITLE
Added parametrization for bin location also in systemd unit

### DIFF
--- a/nomad/files/nomad.service.j2
+++ b/nomad/files/nomad.service.j2
@@ -12,7 +12,7 @@ After=network-online.target
 
 [Service]
 ExecReload=/bin/kill -HUP $MAINPID
-ExecStart=/usr/local/bin/nomad agent -config {{ config_dir }}
+ExecStart={{ bin_dir }}/nomad agent -config {{ config_dir }}
 KillMode=process
 KillSignal=SIGINT
 LimitNOFILE=65536

--- a/nomad/install.sls
+++ b/nomad/install.sls
@@ -141,6 +141,7 @@ nomad-install-service:
     - keep_source: true
     - context:
         config_dir: {{ nomad.config_dir }}
+        bin_dir: {{ nomad.bin_dir }}
     {% else %}
     - source: https://raw.githubusercontent.com/hashicorp/nomad/v{{ nomad.version }}/dist/systemd/nomad.service
     - source_hash: {{ nomad.service_hash }}


### PR DESCRIPTION
I was having issues with the systemd setup since the filepath where the nomad binary is installed is not respected by the systemd unit because it is hard-coded and not taken from pillars.

Here the bug is solved adding proper parametrization.
